### PR TITLE
fix: name references

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,4 +1,4 @@
-import { Auth } from '../services'
+import services from '../services'
 
 export async function login(req, res) {
   /**
@@ -25,7 +25,7 @@ export async function login(req, res) {
     */
 
   try {
-    const user = await Auth.login(req.body)
+    const user = await services.auth.login(req.body)
     return res.json({ user, token: user.generateToken() })
   } catch (err) {
     const error = err.message || 'Can\'t user registration'
@@ -49,7 +49,7 @@ export async function forgotPassword(req, res) {
     */
 
   try {
-    await Auth.forgotPassword(req.body)
+    await services.auth.forgotPassword(req.body)
     return res.json({ status: 'Ok' })
   } catch (err) {
     const error = err.message || 'Can\'t forgot password'
@@ -74,7 +74,7 @@ export async function resetPassword(req, res) {
     */
 
   try {
-    await Auth.resetPassword(req.body)
+    await services.auth.resetPassword(req.body)
     return res.json({ status: 'Ok' })
   } catch (err) {
     const error = err.message || 'Can\'t reset password'

--- a/src/controllers/file.js
+++ b/src/controllers/file.js
@@ -1,4 +1,4 @@
-import { File } from '../services'
+import services from '../services'
 
 export async function create(req, res) {
   /**
@@ -25,7 +25,7 @@ export async function create(req, res) {
     */
 
   try {
-    const file = await File.create(req.file)
+    const file = await services.file.create(req.file)
     return res.json({ file })
   } catch (err) {
     const error = err.message || 'Can\'t upload file'
@@ -57,7 +57,7 @@ export async function destroy(req, res) {
     */
 
   try {
-    const file = await File.destroy({ _id: req.params.id })
+    const file = await services.file.destroy({ _id: req.params.id })
     return res.json({ file })
   } catch (err) {
     const error = err.message || 'Can\'t delete file'

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,3 +1,9 @@
-export * as Auth from './auth'
-export * as File from './file'
-export * as User from './user'
+import * as auth from './auth'
+import * as file from './file'
+import * as user from './user'
+
+export default {
+    auth,
+    file, 
+    user
+}

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,4 +1,4 @@
-import { User } from '../services'
+import services from '../services'
 
 export async function create(req, res) {
   /**
@@ -25,7 +25,7 @@ export async function create(req, res) {
     */
 
   try {
-    const user = await User.create(req.body)
+    const user = await services.user.create(req.body)
     return res.json({ user })
   } catch (err) {
     const error = err.message || 'Can\'t user registration'
@@ -54,7 +54,7 @@ export async function getAll(req, res) {
     */
 
   try {
-    const users = await User.getAll()
+    const users = await services.user.getAll()
     return res.json({ users })
   } catch (err) {
     const error = err.message || 'Can\'t get users informations'
@@ -85,7 +85,7 @@ export async function getOne(req, res) {
     */
 
   try {
-    const user = await User.getOne(req.params.id || req.userId)
+    const user = await services.user.getOne(req.params.id || req.userId)
     return res.json({ user })
   } catch (err) {
     const error = err.message || 'Can\'t get user information'
@@ -122,7 +122,7 @@ export async function update(req, res) {
     */
 
   try {
-    const user = await User.update(req.params.id || req.userId, req.file, req.body)
+    const user = await services.user.update(req.params.id || req.userId, req.file, req.body)
     return res.json({ user })
   } catch (err) {
     const error = err.message || 'Can\'t update user informations'
@@ -153,7 +153,7 @@ export async function destroy(req, res) {
     */
 
   try {
-    const user = await User.destroy(req.params.id)
+    const user = await services.user.destroy(req.params.id)
     return res.json({ user })
   } catch (err) {
     const error = err.message || 'Can\'t delete user'

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { Auth, File, User } from '../controllers'
+import { auth, file, user } from '../controllers'
 
 import multer from 'multer'
 import multerConfig from '../configs/multer'
@@ -7,21 +7,21 @@ import authMiddleware from '../middlewares/auth'
 
 const routes = Router()
 
-routes.post('/user', User.create)
+routes.post('/user', user.create)
 
-routes.post('/login', Auth.login)
-routes.post('/reset_password', Auth.resetPassword)
-routes.post('/forgot_password', Auth.forgotPassword)
+routes.post('/login', auth.login)
+routes.post('/reset_password', auth.resetPassword)
+routes.post('/forgot_password', auth.forgotPassword)
 
 routes.use(authMiddleware)
 
-routes.get('/user', User.getAll)
-routes.get('/user/me', User.getOne)
-routes.get('/user/:id', User.getOne)
-routes.put('/user/:id', multer(multerConfig).single('avatar'), User.update)
-routes.delete('/user/:id', User.destroy)
+routes.get('/user', user.getAll)
+routes.get('/user/me', user.getOne)
+routes.get('/user/:id', user.getOne)
+routes.put('/user/:id', multer(multerConfig).single('avatar'), user.update)
+routes.delete('/user/:id', user.destroy)
 
-routes.post('/file', multer(multerConfig).single('file'), File.create)
-routes.delete('/file/:id', File.destroy)
+routes.post('/file', multer(multerConfig).single('file'), file.create)
+routes.delete('/file/:id', file.destroy)
 
 export default routes

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,7 +10,7 @@ export async function login(body) {
   if(!user)
     throw { message: 'User not found' }
 
-  if(!(await user.compareHash(password)))
+  if(!(await User.compareHash(password)))
     throw { message: 'Invalid password' }
 
   return user
@@ -28,10 +28,10 @@ export async function forgotPassword(body) {
   const expires = new Date()
   expires.setHours(expires.getHours() + 1)
 
-  user.passwordResetToken = token
-  user.passwordResetExpires = expires
+  User.passwordResetToken = token
+  User.passwordResetExpires = expires
 
-  await user.save()
+  await User.save()
 
   await Queue.add('ForgotPasswordMail', { user, token })
 
@@ -54,7 +54,7 @@ export async function resetPassword(body) {
   user.passwordResetToken = null,
   user.passwordResetExpires = null
 
-  await user.save()
+  await User.save()
 
   return null
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,3 +1,9 @@
-export * as Auth from './auth'
-export * as File from './file'
-export * as User from './user'
+import * as auth from './auth'
+import * as file from './file'
+import * as user from './user'
+
+export default {
+    auth,
+    file, 
+    user
+}

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,7 +1,11 @@
 import mongoose from 'mongoose'
 import { User } from '../models'
 
-import { File } from './'
+import { file } from './'
+
+const services = {
+  file
+}
 
 const checkDuplicateEmail = async (email, excludeId) => {
   const user = await User.findOne({ email, _id: { $ne: excludeId } })
@@ -42,12 +46,12 @@ export async function update(id, file, body) {
     throw { message: 'User not found' }
 
   if(file) {
-    const avatar = await File.create(file)
+    const avatar = await services.file.create(file)
     user.avatar = avatar.url
   } else if(body.avatar)
     throw { message: 'Invalid avatar format' }
   else if(body.avatar !== undefined && user.avatar)
-    await File.destroy({ url: user.avatar })
+    await services.file.destroy({ url: user.avatar })
 
   if(body.email)
     await checkDuplicateEmail(body.email, id)


### PR DESCRIPTION
### What this PR does?

- Provides default exports on `index.js` for controllers and services.
- Destructive assignment when importing is only allowed where the module doesn't have a variable with the same name.
- Fixes name references on `users`, `file` and `auth` controllers and services, when providing multiple variables with the same name.


### Did you do it properly?

No.

- [ ] Tests
- [ ] Docs

### Give me more details...

Take this example from `src/routes/index.js`:
```js
routes.post('/login', Auth.login)
```
The script above represents `Auth.login` as a method of the `Auth` class. However, `Auth` handles the request directly (as a controller should do), and passes its parameters to a service with exactly the same name `Auth.login`.

```js
export async function login(req, res) {
 //...

  try {
    const user = await Auth.login(req.body) //this guy, 
    return res.json({ user, token: user.generateToken() })
  } catch (err) {
    const error = err.message || 'Can\'t user registration'
    return res.status(400).json({ error })
  }
}

```
Afterwards, when the service `Auth.login` uses the class method `User.compareHash` to authenticate the user. The stack should look something like this:
```
Auth.login > Auth.login > User.compareHash
```
To avoid this, I'm proposing the following changes:
```
controller.auth.login > service.auth.login > User.compareHash
```
This helps the developer to understand the layer that the request is being made and also avoid name conflicts (`User` the class and `user` the variable). 
